### PR TITLE
add circular knob

### DIFF
--- a/src/Knob.svelte
+++ b/src/Knob.svelte
@@ -5,12 +5,22 @@
         on:mouseup="{onMouseUp}"
         on:touchstart="{onTouchStart}"
         on:touchend="{onTouchEnd}">
-        <path
-            d="{rangePath}"
-            stroke-width="{strokeWidth}"
-            stroke="{secondaryColor}"
-            class="knob-control__range">
-        </path>
+        {#if !circular}
+            <path
+                d="{rangePath}"
+                stroke-width="{strokeWidth}"
+                stroke="{secondaryColor}"
+                class="knob-control__range">
+            </path>
+        {:else}
+            <circle
+                cx={MID_X} cy={MID_Y}
+                r={RADIUS}
+                fill="none"
+                stroke={secondaryColor} stroke-width={strokeWidth}
+                class="knob-control__range"
+            />
+        {/if}
 
         {#if showValue}
         <path
@@ -22,10 +32,14 @@
             style="{dashStyle}"
             class="knob-control__value">
         </path>
+        {/if}
+
+        {#if showNumber}
         <text
             x="50"
-            y="57"
+            y="50"
             text-anchor="middle"
+            alignment-baseline="central"
             fill="{textColor}"
             class="knob-control__text-display">
             {valueDisplay}
@@ -42,8 +56,16 @@ import {
 const RADIUS = 40;
 const MID_X = 50;
 const MID_Y = 50;
-const MIN_RADIANS = 4 * Math.PI / 3;
-const MAX_RADIANS = -Math.PI / 3;
+
+$: MIN_RADIANS = circular
+  ? 2 * Math.PI * 3/4 // bottom
+  : 2 * Math.PI * 4/6 // bottom-left-bottom
+;
+
+$: MAX_RADIANS = circular
+  ? 2 * Math.PI * -1/4 // bottom
+  : 2 * Math.PI * -1/6 // bottom-right-bottom
+;
 
 let pathValue;
 let knob;
@@ -59,10 +81,14 @@ export let animation = {
     animationFunction: 'ease-in-out',
 }
 
+export let circular = false;
+export let modulo = false;
+
 export let value = 0;
 export let max = 100;
 export let min = 0;
 export let showValue = true;
+export let showNumber = true;
 
 export let disabled = false;
 export let step = 1;
@@ -100,9 +126,17 @@ $: style = 'height:' + (responsive ? size + '%' : size - 5 + 'px');
 
 $: computedSize = responsive ? size + '%' : size
 
-$: rangePath = `M ${minX} ${minY} A ${RADIUS} ${RADIUS} 0 1 1 ${maxX} ${maxY}`;
+$: rangePath = circular ? '' : `M ${minX} ${minY} A ${RADIUS} ${RADIUS} 0 1 1 ${maxX} ${maxY}`;
 
-$: valuePath = `M ${zeroX} ${zeroY} A ${RADIUS} ${RADIUS} 0 ${largeArc} ${sweep} ${valueX} ${valueY}`;
+const rangeCircle = {
+  cx: 10,
+  cy: 20,
+};
+
+$: valuePath = circular
+  ? `M ${valueX} ${valueY} A ${RADIUS} ${RADIUS} 0 ${largeArc} ${sweep} ${valueX2} ${valueY2}`
+  : `M ${zeroX} ${zeroY} A ${RADIUS} ${RADIUS} 0 ${largeArc} ${sweep} ${valueX} ${valueY}`
+;
 
 
 $: zeroRadians = (min > 0 && max > 0) ?mapRange(min, min, max, MIN_RADIANS, MAX_RADIANS):mapRange(0, min, max, MIN_RADIANS, MAX_RADIANS);
@@ -121,16 +155,36 @@ $: zeroX = MID_X + Math.cos(zeroRadians) * RADIUS;
 
 $: zeroY =MID_Y - Math.sin(zeroRadians) * RADIUS;
 
-$: valueX =MID_X + Math.cos(valueRadians) * RADIUS;
+// TODO (allow to) use straight line? radius not arc
 
-$: valueY = MID_Y - Math.sin(valueRadians) * RADIUS;
+const circularSize = 0.2;
 
-$: largeArc = Math.abs(zeroRadians - valueRadians) < Math.PI ? 0 : 1;
+$: valueX = circular
+  ? MID_X + Math.cos(valueRadians - circularSize) * RADIUS
+  : MID_X + Math.cos(valueRadians) * RADIUS
+;
 
-$: sweep = valueRadians > zeroRadians ? 0 : 1;
+$: valueY = circular
+  ? MID_Y - Math.sin(valueRadians - circularSize) * RADIUS
+  : MID_Y - Math.sin(valueRadians) * RADIUS
+;
+
+$: valueX2 = circular ? MID_X + Math.cos(valueRadians + circularSize) * RADIUS : 0;
+$: valueY2 = circular ? MID_Y - Math.sin(valueRadians + circularSize) * RADIUS : 0;
+
+$: largeArc = circular ? 0 : (Math.abs(zeroRadians - valueRadians) < Math.PI ? 0 : 1);
+
+$: sweep = circular ? 0 : (valueRadians > zeroRadians ? 0 : 1);
 
 $: valueDisplay = animation.animateValue ? valueDisplayFunction(animatedValue):valueDisplayFunction(value);
 
+function positiveModulo(n, m) {
+    return ((n % m) + m) % m;
+}
+
+let lastAngle = 0;
+let valueBias = 0;
+let angleBias = 0;
 
 function updatePosition(offsetX, offsetY) {
     const dx = offsetX - size / 2;
@@ -140,20 +194,54 @@ function updatePosition(offsetX, offsetY) {
     let mappedValue;
 
     const start = -Math.PI / 2 - Math.PI / 6;
-   
+
+    if (circular) {
+        // detect overflow
+        const angleDiff = angle - lastAngle;
+        if (angleDiff > Math.PI) {
+
+            console.log(`overflow: valueBias ${valueBias} -> ${valueBias + max}`);
+            console.log(`overflow: angleBias ${angleBias} -> ${angleBias - 2*Math.PI - (MAX_RADIANS - MIN_RADIANS)}`);
+
+            valueBias = valueBias + max; // TODO verify: assert min == 0
+            angleBias = angleBias - 2*Math.PI - (MAX_RADIANS - MIN_RADIANS);
+        }
+        else if (angleDiff < (-1 * Math.PI)) {
+
+            console.log(`overflow: valueBias ${valueBias} -> ${valueBias - max}`);
+            console.log(`overflow: angleBias ${angleBias} -> ${angleBias + 2*Math.PI + (MAX_RADIANS - MIN_RADIANS)}`);
+
+            valueBias = valueBias - max; // TODO verify: assert min == 0
+            angleBias = angleBias + 2*Math.PI + (MAX_RADIANS - MIN_RADIANS);
+        }
+
+        mappedValue = mapRange(angleBias + angle + 2 * Math.PI, MIN_RADIANS, MAX_RADIANS, min, max);
+
+        // TODO avoid some calculation if step is disabled
+        value = valueBias + Math.round((mappedValue - min) / step) * step + min;
+        //value = Math.round((mappedValue - min) / step) * step + min;
+
+        if (modulo !== false) {
+            value = positiveModulo(value, modulo);
+        }
+
+        lastAngle = angle;
+        return;
+    }
+
     if (angle > MAX_RADIANS) {
         mappedValue = mapRange(angle, MIN_RADIANS, MAX_RADIANS, min, max);
     } else if (angle < start) {
         mappedValue = mapRange(angle + 2 * Math.PI, MIN_RADIANS, MAX_RADIANS, min, max);
     } else {
        
+        lastAngle = angle;
         return;
     }
     
 
     value = Math.round((mappedValue - min) / step) * step + min;
-
- 
+    lastAngle = angle;
 };
 
 function onClick(e) {
@@ -235,6 +323,10 @@ function mapRange(x, inMin, inMax, outMin, outMax)  {
     100% {
         stroke-dashoffset: 0;
     }
+}
+
+.knob-control {
+    user-select: none; /* disable text selection on click + drag */
 }
 
 .knob-control__range {


### PR DESCRIPTION
add a new "circular" mode, where min/max are not hard limits, and the value can be increased/decreased continuously.
this is useful to select angles (degrees) or to control wide ranges with good precision (turntables).

in this context, "max" is the value of one full circle.
the value zero is always on the bottom of the knob (south, earth).

the calculations are probably somewhat redundant, and could be made more efficient, but for now im happy that it works : )

usage:

```svelte
<Knob circular={true} />
<Knob circular={true} max={360} />
<Knob circular={true} max={360} modulo={360} />

<!-- allow to show value but hide number -->
<Knob showNumber={false} />

<!-- allow to set value to undefined by clicking the knob center -->
<Knob circular={true} allowUndefined={true} bind:value={knobValue} showNumber={false} />
```

result (left knob has value undefined) (the numbers are rendered by a different component)

<img width="256" alt="svelte-knob Screenshot_20210224_211447" src="https://user-images.githubusercontent.com/12958815/109060330-8e2f8780-76e5-11eb-80aa-e6acd37e66d1.png">

todo:

* fix the `min` parameter. its expected to be zero. if not zero, numbers are wrong
* allow to change the zero position, for example with a parameter `zeroAngle`
* maybe add a different style for the value indicator: arc vs radius
* allow the "linear" knob (with hard min/max limits) to show a direction, not a sector
* allow to input "diagonal" values = show two handles 180 degrees apart

small fixes:

* disable text selection via CSS
* properly vertical center the text in SVG
